### PR TITLE
Migrate the queue backend from Bull to BullMQ (v4.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Test
         run: yarn test
 
-      - name: Integration test (real Redis + Bull)
+      - name: Integration test (real Redis + BullMQ)
         run: yarn test:integration
         env:
           REDIS_HOST: localhost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2026-08-18
+
+### Changed
+
+- **BREAKING:** Migrated the queue backend from Bull to
+  [BullMQ](https://github.com/taskforcesh/bullmq) (Bull is in maintenance mode).
+  `processQueue()` now returns a BullMQ **`Worker`** instead of a Bull `Queue`. The event
+  API is the same shape — attach `worker.on("completed", …)` / `worker.on("failed", …)` —
+  but any code that called `Queue`-only methods (e.g. `obliterate()`, `getJobCounts()`) on
+  the return value must be updated.
+- **BREAKING:** Requires **Redis 5.0+** (6.2+ recommended), per BullMQ.
+- `config.redis` now accepts BullMQ's `ConnectionOptions` (an ioredis options object or
+  instance). Passing `{ host, port, … }` is unchanged.
+- Replaced the `bull` dependency with `bullmq`, and added `ioredis` as a direct dependency
+  (BullMQ 6 makes it an optional peer, whereas Bull bundled it).
+
+### Notes
+
+- `contents()`, `deliverNow()`, and `deliverLater()` semantics are unchanged, as is the
+  message/config shape apart from the widened `redis` type. Internally, queued jobs are now
+  added under a fixed BullMQ job name.
+
 ## [3.0.2] - 2026-08-18
 
 ### Changed
@@ -69,6 +91,7 @@ All notable changes to this project are documented here. The format is based on
 - Initial releases (1.0.0 – 1.1.0): the original Redis-backed mailer queue wrapping
   Nodemailer and Bull.
 
+[4.0.0]: https://github.com/Mailer-Q/Mailer-Q/releases/tag/v4.0.0
 [3.0.2]: https://github.com/Mailer-Q/Mailer-Q/releases/tag/v3.0.2
 [3.0.0]: https://github.com/Mailer-Q/Mailer-Q/releases/tag/v3.0.0
 [2.0.2]: https://github.com/Mailer-Q/Mailer-Q/releases/tag/v2.0.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-`mailer-q` is a published npm package: a small, Redis-backed mailer queue that wraps [Nodemailer](https://nodemailer.com/) for sending and [Bull](https://github.com/OptimalBits/bull) for queueing. It is written in TypeScript under `src/` and compiled with `tsc` to `dist/` (CommonJS + `.d.ts`), which `package.json` declares via `main`/`types`. Only `dist/` is published (`files: ["dist"]`); `dist/` is gitignored and rebuilt on `prepublishOnly`.
+`mailer-q` is a published npm package: a small, Redis-backed mailer queue that wraps [Nodemailer](https://nodemailer.com/) for sending and [BullMQ](https://github.com/taskforcesh/bullmq) for queueing (with `ioredis` as the Redis client). It is written in TypeScript under `src/` and compiled with `tsc` to `dist/` (CommonJS + `.d.ts`), which `package.json` declares via `main`/`types`. Only `dist/` is published (`files: ["dist"]`); `dist/` is gitignored and rebuilt on `prepublishOnly`.
 
 ## Commands
 
@@ -13,17 +13,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Lint:** `npm run lint` (`eslint . --ext .ts`, with `@typescript-eslint` + Prettier).
 - **Publish:** version bumps are standalone commits (see git history). `prepublishOnly` builds first; `npm publish` ships `dist/`, `README.md`, `package.json`.
 
-Tests mock `nodemailer` and `bull` (via `vi.mock`), so they need no real SMTP server or Redis.
+Tests mock `nodemailer` and `bullmq` (via `vi.mock`), so they need no real SMTP server or Redis. The exception is `tests/queue.integration.test.ts`, which runs against a real Redis + BullMQ (gated on `REDIS_HOST`; `yarn test:integration`).
 
 ## Architecture
 
 `MailerQ(config)` (default export in `src/index.ts`) is a **factory** returning an instance `{ contents, processQueue, close }`. It is a breaking change from v2's `MailerQ().config(options)` chain — see the README upgrade note.
 
-- The transporter and Bull queue are created **lazily and memoized** on the instance, then reused across sends. `getQueue()` throws if `config.redis` is absent.
+- The transporter and BullMQ queue are created **lazily and memoized** on the instance, then reused across sends. A shared `connection()` guard throws if `config.redis` is absent (used by both `getQueue()` and `processQueue()`).
 - `contents(message)` builds the Nodemailer payload via the pure `buildPayload()` in `src/payload.ts` and returns a **fresh envelope** `{ payload, deliverNow, deliverLater }` that closes over that payload. No per-message state is stored on the instance — this is deliberate, to avoid the v2 shared-mutable-`messagePayload` race.
   - `deliverNow()` resolves with Nodemailer's `SentMessageInfo`.
-  - `deliverLater()` is a **producer only**: it enqueues and resolves with the Bull `Job`.
-- `processQueue()` is the **consumer**: run once in a worker process, it registers the queue processor and returns the Bull queue (for `completed`/`failed` listeners). Keep producer (`deliverLater`) and consumer (`processQueue`) separate — do not re-merge them into one call, which was the v2 bug (per-call queues leaked Redis connections and resolved on the wrong job).
+  - `deliverLater()` is a **producer only**: it enqueues (via the BullMQ `Queue`) and resolves with the `Job`. BullMQ requires a job name, so it adds under `JOB_NAME`.
+- `processQueue()` is the **consumer**: run once in a worker process, it creates and memoizes a BullMQ `Worker` and returns it (for `completed`/`failed` listeners). Keep producer (`deliverLater`) and consumer (`processQueue`) separate — do not re-merge them into one call, which was the v2 bug (per-call queues leaked Redis connections and resolved on the wrong job).
 - `close()` closes the queue and transporter for graceful shutdown.
 
 `buildPayload()` (`src/payload.ts`) applies `defaultFrom`/`defaultTo`, validates that a recipient and `subject` are present, and only invokes `config.renderer` when a `templateFileName` is given (otherwise falls back to `htmlBody`).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![license](https://img.shields.io/npm/l/mailer-q.svg)](./LICENSE)
 
 MailerQ is a small, Redis-backed mailer queue for Node.js, written in TypeScript. It wraps
-[Nodemailer](https://nodemailer.com/) for sending and [Bull](https://github.com/OptimalBits/bull)
+[Nodemailer](https://nodemailer.com/) for sending and [BullMQ](https://github.com/taskforcesh/bullmq)
 for queueing, so you can send mail immediately or enqueue it for a worker to deliver — with
 pluggable template renderers and typed configuration.
 
@@ -42,8 +42,8 @@ module.exports = MailerQ(options);
 - **defaultTo** (Optional): Set the default recipient (not common).
 - **renderer** (Optional): Method to render email templates.
 - **sendAttempts** (Optional): Number of times MailerQ will attempt to send queued mail. Defaults to 3.
-- **redis** (Optional): Redis connection options (from [ioredis](https://github.com/redis/ioredis)). Required for `deliverLater` and `processQueue`.
-- **queueName** (Optional): Name of the Bull queue. Defaults to `"MailerQ SendEmail Process"`.
+- **redis** (Optional): Redis connection options (BullMQ's `ConnectionOptions` — an [ioredis](https://github.com/redis/ioredis) options object or instance). Requires Redis 5.0+ (6.2+ recommended). Required for `deliverLater` and `processQueue`.
+- **queueName** (Optional): Name of the BullMQ queue. Defaults to `"MailerQ SendEmail Process"`.
 
 Example:
 
@@ -78,7 +78,7 @@ Build the message content with `contents()`, then chain either `deliverNow()` or
 `deliverLater()`:
 
 - `deliverNow()` sends immediately and resolves with Nodemailer's `info`.
-- `deliverLater()` enqueues the message and resolves with the Bull `Job`. A worker then
+- `deliverLater()` enqueues the message and resolves with the BullMQ `Job`. A worker then
   processes it (see [Processing the queue](#processing-the-queue)).
 
 ```javascript
@@ -112,16 +112,16 @@ MailerQ.contents({
 ### Processing the queue
 
 `deliverLater()` only enqueues. Run `processQueue()` **once in a worker process** to
-consume the queue and actually send the mail. It returns the underlying Bull queue so you
-can listen for events:
+consume the queue and actually send the mail. It returns the underlying BullMQ
+[`Worker`](https://docs.bullmq.io/guide/workers) so you can listen for events:
 
 ```javascript
 const MailerQ = require("./config/mailers");
 
-const queue = MailerQ.processQueue();
+const worker = MailerQ.processQueue();
 
-queue.on("completed", (job) => console.log("Sent:", job.id));
-queue.on("failed", (job, err) => console.error("Failed:", job.id, err));
+worker.on("completed", (job) => console.log("Sent:", job.id));
+worker.on("failed", (job, err) => console.error("Failed:", job.id, err));
 ```
 
 ### Shutting down

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailer-q",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Mailer-Q/Mailer-Q.git"
@@ -26,7 +26,8 @@
   "author": "Aaron Sood",
   "license": "MIT",
   "dependencies": {
-    "bull": "^4.16.3",
+    "bullmq": "^6.1.2",
+    "ioredis": "^6.0.0",
     "nodemailer": "^9.0.5"
   },
   "devDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,4 @@
 export const DEFAULT_SEND_ATTEMPTS = 3;
 export const DEFAULT_QUEUE_NAME = "MailerQ SendEmail Process";
+/** BullMQ requires a name for every job added to a queue. */
+export const JOB_NAME = "send";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
-import Queue from "bull";
+import { Queue, Worker } from "bullmq";
 import nodemailer from "nodemailer";
 import type { Transporter } from "nodemailer";
 import type Mail from "nodemailer/lib/mailer";
 
-import { DEFAULT_QUEUE_NAME, DEFAULT_SEND_ATTEMPTS } from "./constants";
+import {
+  DEFAULT_QUEUE_NAME,
+  DEFAULT_SEND_ATTEMPTS,
+  JOB_NAME,
+} from "./constants";
 import { buildPayload } from "./payload";
 import type {
   Envelope,
@@ -15,13 +19,15 @@ import type {
 /**
  * Create a MailerQ instance bound to a configuration.
  *
- * The transporter and queue are created lazily and reused across sends, and the
+ * The transporter and queue are created lazily and reused across sends. The
  * queue is used strictly as a producer by `deliverLater`; call `processQueue`
- * once in a worker process to consume it. Call `close` for a graceful shutdown.
+ * once in a worker process to spin up the BullMQ worker that consumes it. Call
+ * `close` for a graceful shutdown.
  */
 const MailerQ = (config: MailerQConfig): MailerQInstance => {
   let transporter: Transporter | undefined;
-  let queue: Queue.Queue<Mail.Options> | undefined;
+  let queue: Queue<Mail.Options> | undefined;
+  let worker: Worker<Mail.Options> | undefined;
 
   const getTransporter = (): Transporter => {
     if (!transporter) {
@@ -30,15 +36,21 @@ const MailerQ = (config: MailerQConfig): MailerQInstance => {
     return transporter;
   };
 
-  const getQueue = (): Queue.Queue<Mail.Options> => {
+  // Producer and consumer both need a Redis connection; require it up front so
+  // the failure is a clear config error rather than a connection timeout.
+  const connection = () => {
     if (!config.redis) {
       throw new Error(
         "MailerQ: `deliverLater` and `processQueue` require a Redis config. None was found.",
       );
     }
+    return config.redis;
+  };
+
+  const getQueue = (): Queue<Mail.Options> => {
     if (!queue) {
       queue = new Queue<Mail.Options>(config.queueName ?? DEFAULT_QUEUE_NAME, {
-        redis: config.redis,
+        connection: connection(),
       });
     }
     return queue;
@@ -51,21 +63,30 @@ const MailerQ = (config: MailerQConfig): MailerQInstance => {
       payload,
       deliverNow: () => getTransporter().sendMail(payload),
       deliverLater: (options) =>
-        getQueue().add(payload, {
+        getQueue().add(JOB_NAME, payload, {
           attempts: config.sendAttempts ?? DEFAULT_SEND_ATTEMPTS,
           ...options,
         }),
     };
   };
 
-  const processQueue = (): Queue.Queue<Mail.Options> => {
-    const q = getQueue();
+  const processQueue = (): Worker<Mail.Options> => {
+    const conn = connection();
     const t = getTransporter();
-    q.process((job) => t.sendMail(job.data));
-    return q;
+    if (!worker) {
+      worker = new Worker<Mail.Options>(
+        config.queueName ?? DEFAULT_QUEUE_NAME,
+        (job) => t.sendMail(job.data),
+        { connection: conn },
+      );
+    }
+    return worker;
   };
 
   const close = async (): Promise<void> => {
+    if (worker) {
+      await worker.close();
+    }
     if (queue) {
       await queue.close();
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
-import type { Job, JobOptions, Queue } from "bull";
-import type { RedisOptions } from "ioredis";
+import type { ConnectionOptions, Job, JobsOptions, Worker } from "bullmq";
 import type { SentMessageInfo, Transporter } from "nodemailer";
 import type Mail from "nodemailer/lib/mailer";
 import type SMTPTransport from "nodemailer/lib/smtp-transport";
@@ -27,9 +26,10 @@ export interface MailerQConfig {
   renderer?: MailerQRenderer;
   /** Retry attempts for queued sends. Defaults to DEFAULT_SEND_ATTEMPTS. */
   sendAttempts?: number;
-  /** Redis connection options. Required for `deliverLater` / `processQueue`. */
-  redis?: RedisOptions;
-  /** Bull queue name. Defaults to DEFAULT_QUEUE_NAME. */
+  /** Redis connection options (BullMQ `ConnectionOptions`; an ioredis instance
+   * is also accepted). Required for `deliverLater` / `processQueue`. */
+  redis?: ConnectionOptions;
+  /** BullMQ queue name. Defaults to DEFAULT_QUEUE_NAME. */
   queueName?: string;
 }
 
@@ -53,8 +53,8 @@ export interface Envelope {
   readonly payload: Mail.Options;
   /** Send immediately; resolves with Nodemailer's send info. */
   deliverNow: () => Promise<SentMessageInfo>;
-  /** Enqueue for a worker to process later; resolves with the Bull job. */
-  deliverLater: (options?: JobOptions) => Promise<Job<Mail.Options>>;
+  /** Enqueue for a worker to process later; resolves with the BullMQ job. */
+  deliverLater: (options?: JobsOptions) => Promise<Job<Mail.Options>>;
 }
 
 export interface MailerQInstance {
@@ -62,10 +62,10 @@ export interface MailerQInstance {
   contents: (message: MailerQMessage) => Envelope;
   /**
    * Start processing queued messages. Run once in a worker process; returns the
-   * underlying Bull queue so callers can attach `completed`/`failed` listeners.
+   * BullMQ worker so callers can attach `completed`/`failed` listeners.
    */
-  processQueue: () => Queue<Mail.Options>;
-  /** Gracefully close the queue and transporter connections. */
+  processQueue: () => Worker<Mail.Options>;
+  /** Gracefully close the queue, worker, and transporter connections. */
   close: () => Promise<void>;
 }
 

--- a/tests/queue.integration.test.ts
+++ b/tests/queue.integration.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { Queue } from "bullmq";
 
 import MailerQ from "../src/index";
 import type { MailerQConfig } from "../src/types";
 
 /**
- * End-to-end queue test against a REAL Redis and REAL Bull (the unit tests in
+ * End-to-end queue test against a REAL Redis and REAL BullMQ (the unit tests in
  * queue.test.ts mock both). Nodemailer runs with `jsonTransport`, so no SMTP
  * server is needed — sends resolve locally with the message as JSON.
  *
@@ -25,29 +26,30 @@ const jsonTransport = {
   jsonTransport: true,
 } as unknown as MailerQConfig["nodemailer"];
 
-describeIntegration("MailerQ queue (integration: real Redis + Bull)", () => {
+describeIntegration("MailerQ queue (integration: real Redis + BullMQ)", () => {
   const redis = {
     host: redisHost ?? "127.0.0.1",
     port: Number(process.env.REDIS_PORT ?? 6379),
   };
 
   it("delivers a queued message end to end via deliverLater + processQueue", async () => {
+    // Unique queue name per run so leftover jobs can't bleed between runs.
+    const queueName = `mailer-q-itest-${Date.now()}`;
     const mailer = MailerQ({
       nodemailer: jsonTransport,
       redis,
-      // Unique queue name per run so leftover jobs can't bleed between runs.
-      queueName: `mailer-q-itest-${Date.now()}`,
+      queueName,
       sendAttempts: 1,
     });
 
-    const queue = mailer.processQueue();
+    const worker = mailer.processQueue();
 
     const completed = new Promise<{ jobId: string; result: SendInfo }>(
       (resolve, reject) => {
-        queue.on("completed", (job, result) =>
+        worker.on("completed", (job, result) =>
           resolve({ jobId: String(job.id), result: result as SendInfo }),
         );
-        queue.on("failed", (_job, err) => reject(err));
+        worker.on("failed", (_job, err) => reject(err));
       },
     );
 
@@ -70,12 +72,16 @@ describeIntegration("MailerQ queue (integration: real Redis + Bull)", () => {
     expect(message.subject).toBe("Integration test");
     expect(result.message).toContain("recipient@example.com");
 
-    await queue.obliterate({ force: true });
+    // Clean up the run's Redis keys (obliterate lives on the queue, not the
+    // worker) and close every connection.
+    const cleanup = new Queue(queueName, { connection: redis });
+    await cleanup.obliterate({ force: true });
+    await cleanup.close();
     await mailer.close();
   }, 20000);
 });
 
-// Minimal shape of nodemailer's jsonTransport SentMessageInfo, after Bull's
+// Minimal shape of nodemailer's jsonTransport SentMessageInfo, after BullMQ's
 // JSON round-trip through Redis.
 interface SendInfo {
   messageId: string;

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -1,23 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  QueueMock,
-  add,
-  process: processFn,
-  queueClose,
-} = vi.hoisted(() => {
-  const add = vi.fn(async () => ({ id: "job-1" }));
-  const processFn = vi.fn();
-  const queueClose = vi.fn(async () => undefined);
-  const QueueMock = vi.fn(() => ({
-    add,
-    process: processFn,
-    close: queueClose,
-  }));
-  return { QueueMock, add, process: processFn, queueClose };
-});
+const { QueueMock, WorkerMock, add, queueClose, workerClose } = vi.hoisted(
+  () => {
+    const add = vi.fn(async () => ({ id: "job-1" }));
+    const queueClose = vi.fn(async () => undefined);
+    const workerClose = vi.fn(async () => undefined);
+    const QueueMock = vi.fn(() => ({ add, close: queueClose }));
+    const WorkerMock = vi.fn(() => ({ close: workerClose }));
+    return { QueueMock, WorkerMock, add, queueClose, workerClose };
+  },
+);
 
-vi.mock("bull", () => ({ default: QueueMock }));
+vi.mock("bullmq", () => ({ Queue: QueueMock, Worker: WorkerMock }));
 vi.mock("nodemailer", () => ({
   default: {
     createTransport: vi.fn(() => ({ sendMail: vi.fn(), close: vi.fn() })),
@@ -25,7 +19,7 @@ vi.mock("nodemailer", () => ({
 }));
 
 import MailerQ from "../src/index";
-import { DEFAULT_QUEUE_NAME } from "../src/constants";
+import { DEFAULT_QUEUE_NAME, JOB_NAME } from "../src/constants";
 
 const redis = { host: "127.0.0.1", port: 6379 };
 
@@ -41,7 +35,8 @@ describe("deliverLater", () => {
       .deliverLater();
 
     expect(add).toHaveBeenCalledTimes(1);
-    const [payload, options] = add.mock.calls[0];
+    const [name, payload, options] = add.mock.calls[0];
+    expect(name).toBe(JOB_NAME);
     expect(payload).toMatchObject({ to: "to@example.com", subject: "Hi" });
     expect(options).toMatchObject({ attempts: 3 });
     expect(job).toEqual({ id: "job-1" });
@@ -58,8 +53,10 @@ describe("deliverLater", () => {
       .contents({ to: "to@example.com", subject: "Hi" })
       .deliverLater();
 
-    expect(QueueMock).toHaveBeenCalledWith("custom-queue", { redis });
-    expect(add.mock.calls[0][1]).toMatchObject({ attempts: 7 });
+    expect(QueueMock).toHaveBeenCalledWith("custom-queue", {
+      connection: redis,
+    });
+    expect(add.mock.calls[0][2]).toMatchObject({ attempts: 7 });
   });
 
   it("uses the default queue name when none is configured", async () => {
@@ -68,7 +65,9 @@ describe("deliverLater", () => {
       .contents({ to: "to@example.com", subject: "Hi" })
       .deliverLater();
 
-    expect(QueueMock).toHaveBeenCalledWith(DEFAULT_QUEUE_NAME, { redis });
+    expect(QueueMock).toHaveBeenCalledWith(DEFAULT_QUEUE_NAME, {
+      connection: redis,
+    });
   });
 
   it("reuses a single queue instance across enqueues", async () => {
@@ -89,17 +88,31 @@ describe("deliverLater", () => {
 });
 
 describe("processQueue", () => {
-  it("registers a processor exactly once and returns the queue", () => {
+  it("starts a worker exactly once and returns it", () => {
     const mailer = MailerQ({ nodemailer: {}, redis });
-    const queue = mailer.processQueue();
+    const worker = mailer.processQueue();
 
-    expect(processFn).toHaveBeenCalledTimes(1);
-    expect(queue).toBeDefined();
+    expect(WorkerMock).toHaveBeenCalledTimes(1);
+    // (queueName, processor, { connection })
+    const [name, processor, options] = WorkerMock.mock.calls[0];
+    expect(name).toBe(DEFAULT_QUEUE_NAME);
+    expect(typeof processor).toBe("function");
+    expect(options).toMatchObject({ connection: redis });
+    expect(worker).toBeDefined();
+  });
+
+  it("reuses a single worker across calls", () => {
+    const mailer = MailerQ({ nodemailer: {}, redis });
+    mailer.processQueue();
+    mailer.processQueue();
+
+    expect(WorkerMock).toHaveBeenCalledTimes(1);
   });
 
   it("throws when no redis config is provided", () => {
     const mailer = MailerQ({ nodemailer: {} });
     expect(() => mailer.processQueue()).toThrow(/require a Redis config/);
+    expect(WorkerMock).not.toHaveBeenCalled();
   });
 });
 
@@ -112,9 +125,18 @@ describe("close", () => {
     expect(queueClose).toHaveBeenCalledTimes(1);
   });
 
+  it("closes the worker when one was created", async () => {
+    const mailer = MailerQ({ nodemailer: {}, redis });
+    mailer.processQueue();
+    await mailer.close();
+
+    expect(workerClose).toHaveBeenCalledTimes(1);
+  });
+
   it("is a no-op when nothing was ever created", async () => {
     const mailer = MailerQ({ nodemailer: {}, redis });
     await expect(mailer.close()).resolves.toBeUndefined();
     expect(queueClose).not.toHaveBeenCalled();
+    expect(workerClose).not.toHaveBeenCalled();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,10 +188,10 @@
   resolved "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz"
   integrity sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==
 
-"@ioredis/commands@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz"
-  integrity sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==
+"@ioredis/commands@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-2.0.0.tgz#7207c56e0be51fd9f2ec2505ebdb9372a3ceb76d"
+  integrity sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==
 
 "@ioredis/commands@^1.4.0":
   version "1.11.0"
@@ -205,7 +205,7 @@
 
 "@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4":
   version "3.0.4"
-  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz#22619f76a6b10ba78c8b74025b0d9754cad69cc7"
   integrity sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==
 
 "@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4":
@@ -647,18 +647,16 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-bull@^4.16.3:
-  version "4.16.5"
-  resolved "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz"
-  integrity sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==
+bullmq@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/bullmq/-/bullmq-6.1.2.tgz#f13183db9d41ba6b93ae7bf65d266ce5fd6840bc"
+  integrity sha512-GSX8JfWN8CElAGDyt7Zmq59n1FfWZ0L7IjsThNUQq7X8mvVVDb9I5i2F+nFg4A00UbysJ5yejN0oWzmbUJPDFg==
   dependencies:
-    cron-parser "^4.9.0"
-    get-port "^5.1.1"
-    ioredis "^5.3.2"
-    lodash "^4.17.21"
-    msgpackr "^1.11.2"
-    semver "^7.5.2"
-    uuid "^8.3.0"
+    cron-parser "5.10.0"
+    msgpackr "2.0.5"
+    node-abort-controller "3.1.1"
+    semver "7.8.5"
+    tslib "2.8.1"
 
 cac@^6.7.14:
   version "6.7.14"
@@ -694,7 +692,7 @@ check-error@^2.1.1:
 
 cluster-key-slot@1.1.1:
   version "1.1.1"
-  resolved "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz#10ccb9ded0729464b6d2e7d714b100a2d1259d43"
   integrity sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==
 
 color-convert@^2.0.1:
@@ -711,12 +709,12 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
 
-cron-parser@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz"
-  integrity sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==
+cron-parser@5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-5.10.0.tgz#94799d9ddd56b893aa8e4a4c7f19717ee7d1ebe4"
+  integrity sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==
   dependencies:
-    luxon "^3.2.1"
+    luxon "^3.7.2"
 
 cross-spawn@^7.0.2:
   version "7.0.6"
@@ -745,12 +743,12 @@ deep-is@^0.1.3:
 
 denque@2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
   integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 detect-libc@^2.0.1:
   version "2.1.2"
-  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 dir-glob@^3.0.1:
@@ -1014,10 +1012,6 @@ fsevents@~2.3.2, fsevents@~2.3.3:
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-get-port@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz"
-
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
@@ -1109,17 +1103,16 @@ ioredis-mock@^8.9.0:
     fengari-interop "^0.1.3"
     semver "^7.7.2"
 
-ioredis@^5.3.2:
-  version "5.11.1"
-  resolved "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz"
-  integrity sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==
+ioredis@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-6.0.0.tgz#b757c590547c43a5e18ea9c312d05c5c46c7e6fa"
+  integrity sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==
   dependencies:
-    "@ioredis/commands" "1.10.0"
+    "@ioredis/commands" "2.0.0"
     cluster-key-slot "1.1.1"
     debug "4.4.3"
     denque "2.1.0"
     redis-errors "1.2.0"
-    redis-parser "3.0.0"
     standard-as-callback "2.1.0"
 
 is-extglob@^2.1.1:
@@ -1191,19 +1184,14 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
 
-lodash@^4.17.21:
-  version "4.18.1"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz"
-  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
-
 loupe@^3.1.0, loupe@^3.1.4:
   version "3.2.1"
   resolved "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz"
   integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
 
-luxon@^3.2.1:
+luxon@^3.7.2:
   version "3.7.2"
-  resolved "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
   integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==
 
 magic-string@^0.30.17:
@@ -1245,9 +1233,9 @@ ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-msgpackr-extract@^3.0.2:
+msgpackr-extract@^3.0.4:
   version "3.0.4"
-  resolved "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz#d252698947f7a1a62478d22bfb789ba48dd4c1ac"
   integrity sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==
   dependencies:
     node-gyp-build-optional-packages "5.2.2"
@@ -1259,12 +1247,12 @@ msgpackr-extract@^3.0.2:
     "@msgpackr-extract/msgpackr-extract-linux-x64" "3.0.4"
     "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.4"
 
-msgpackr@^1.11.2:
-  version "1.12.1"
-  resolved "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz"
-  integrity sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==
+msgpackr@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-2.0.5.tgz#ea4308164fad112f1bd4a7bf008445a8a613658a"
+  integrity sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==
   optionalDependencies:
-    msgpackr-extract "^3.0.2"
+    msgpackr-extract "^3.0.4"
 
 nanoid@^3.3.17:
   version "3.3.18"
@@ -1275,9 +1263,14 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
 
+node-abort-controller@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
+  integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
+
 node-gyp-build-optional-packages@5.2.2:
   version "5.2.2"
-  resolved "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz#522f50c2d53134d7f3a76cd7255de4ab6c96a3a4"
   integrity sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==
   dependencies:
     detect-libc "^2.0.1"
@@ -1407,16 +1400,10 @@ readline-sync@^1.4.10:
   resolved "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz"
   integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
 
-redis-errors@1.2.0, redis-errors@^1.0.0:
+redis-errors@1.2.0:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz"
-
-redis-parser@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz"
-  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
-  dependencies:
-    redis-errors "^1.0.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -1475,7 +1462,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-semver@^7.5.2, semver@^7.6.0, semver@^7.7.2:
+semver@7.8.5, semver@^7.6.0, semver@^7.7.2:
   version "7.8.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
@@ -1517,7 +1504,7 @@ stackback@0.0.2:
 
 standard-as-callback@2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
   integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 std-env@^3.9.0:
@@ -1610,6 +1597,11 @@ ts-api-utils@^1.3.0:
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz"
   integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
 
+tslib@2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
@@ -1640,10 +1632,6 @@ uri-js@^4.2.2:
   resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
   dependencies:
     punycode "^2.1.0"
-
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
 
 vite-node@3.2.4:
   version "3.2.4"


### PR DESCRIPTION
## Summary

Bull is in maintenance mode; this migrates the queue backend to its successor **[BullMQ](https://github.com/taskforcesh/bullmq)**. MailerQ's existing producer/consumer split maps almost 1:1 onto BullMQ's `Queue` (producer) / `Worker` (consumer) model, so the change is well-contained.

- `deliverLater()` enqueues via a BullMQ `Queue` (jobs added under a fixed job name, which BullMQ requires).
- `processQueue()` creates and memoizes a BullMQ **`Worker`** and returns it; event wiring keeps the same shape (`worker.on("completed" | "failed", …)`).
- `close()` now closes the worker, queue, and transporter.
- A shared `connection()` guard requires `config.redis` for both the producer and consumer paths.

## Breaking changes (→ 4.0.0)

- **`processQueue()` returns a BullMQ `Worker` instead of a Bull `Queue`.** Event listeners are unchanged in shape, but code calling `Queue`-only methods (e.g. `obliterate()`, `getJobCounts()`) on the return value must adapt.
- **Requires Redis 5.0+** (6.2+ recommended), per BullMQ.
- `config.redis` now takes BullMQ's `ConnectionOptions` (an ioredis options object or instance). Passing `{ host, port, … }` is unchanged.
- Dependencies: replaced `bull` with `bullmq`, and added `ioredis` as a direct dependency (BullMQ 6 makes `ioredis` an optional peer, whereas `bull` bundled it).

Unchanged: `contents()`, `deliverNow()`, `deliverLater()` semantics and the message/config shape (apart from the widened `redis` type).

## Tests

- **Unit tests** mock `bullmq`'s `Queue`/`Worker` — 23 passing.
- **Integration test** (real Redis + real BullMQ) drives `deliverLater` → `Worker` → `completed` end to end and cleans up via a `Queue` handle. Verified green locally against Redis 7 + BullMQ 6; CI runs it against the `redis:7` service.

## Notes

Not published. This is `4.0.0` in `package.json` + CHANGELOG; publishing happens later via a `v4.0.0` tag through the existing workflow. README and CLAUDE.md updated to reflect BullMQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
